### PR TITLE
chore: Bump version to 1.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wildcomponents",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wildcomponents",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "ISC",
       "dependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildcomponents",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
This pull request bumps the version to 1.0.32. The changes include updates to package.json and package-lock.json to reflect the new version.